### PR TITLE
Support per-domain toggle for cloudflare proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | `DOMAIN1_PROXIED`   | Domain 1 True of False if proxied |
 | `DOMAIN2`   | (optional Domain 2 you wish to update records for. |
 | `DOMAIN2_ZONE_ID`   | Domain 2 Zone ID from Cloudflare |
-| `DOMAIN1_PROXIED`   | Domain 1 True of False if proxied |
+| `DOMAIN2_PROXIED`   | Domain 1 True of False if proxied |
 | `DOMAIN3....`   | And so on.. |
 
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | `TARGET_DOMAIN` | Destination Host to forward records to e.g. ``host.example.com` |
 | `DOMAIN1`   | Domain 1 you wish to update records for. |
 | `DOMAIN1_ZONE_ID`   | Domain 1 Zone ID from Cloudflare |
+| `DOMAIN1_PROXIED`   | Domain 1 True of False if proxied |
 | `DOMAIN2`   | (optional Domain 2 you wish to update records for. |
 | `DOMAIN2_ZONE_ID`   | Domain 2 Zone ID from Cloudflare |
+| `DOMAIN1_PROXIED`   | Domain 1 True of False if proxied |
 | `DOMAIN3....`   | And so on.. |
 
 
@@ -73,7 +75,7 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 # Maintenance
 #### Shell Access
 
-For debugging and maintenance purposes you may want access the containers shell. 
+For debugging and maintenance purposes you may want access the containers shell.
 
 ```bash
 docker exec -it (whatever your container name is e.g. nginx-proxy-cloudflare-companion) bash

--- a/install/etc/s6/services/10-cloudflare-companion/run
+++ b/install/etc/s6/services/10-cloudflare-companion/run
@@ -24,7 +24,7 @@ EOF
         domain${i} = os.environ['DOMAIN${i}']
         zone_id${i} = os.environ['DOMAIN${i}_ZONE_ID']
         try:
-            if os.environ['DOMAIN${i}_PROXIED'] == "True":
+            if os.environ['DOMAIN${i}_PROXIED'].upper() == "TRUE":
                 proxied_flag${i} = True
             else:
                 proxied_flag${i} = False

--- a/install/etc/s6/services/10-cloudflare-companion/run
+++ b/install/etc/s6/services/10-cloudflare-companion/run
@@ -20,11 +20,19 @@ EOF
     for (( i = 1; i <= 2; i++ ))
     do
         cat <<EOF >> /usr/sbin/cloudflare-companion.py
-    
+
         domain${i} = os.environ['DOMAIN${i}']
         zone_id${i} = os.environ['DOMAIN${i}_ZONE_ID']
+        try:
+            if os.environ['DOMAIN${i}_PROXIED'] == "True":
+                proxied_flag${i} = True
+            else:
+                proxied_flag${i} = False
+        except KeyError:
+            proxied_flag${i} = False
+
         if name.find(domain${i}) != -1:
-            r = cf.zones.dns_records.post(zone_id${i},data={u'type': u'CNAME', u'name': name, u'content': target_domain, u'ttl': 120, u'proxied': False} )
+            r = cf.zones.dns_records.post(zone_id${i},data={u'type': u'CNAME', u'name': name, u'content': target_domain, u'ttl': 120, u'proxied': proxied_flag${i}} )
 
 EOF
 done
@@ -99,5 +107,3 @@ fi
 echo ''
 echo '** Starting Cloudflare Companion'
 exec python -u /usr/sbin/cloudflare-companion.py
-
-


### PR DESCRIPTION
Add a DOMAIN\d_PROXIED flag that allows defining if a domain is proxied by cloudflare or not. Existing behaviour was to default to False.

Default is still false, changes if user supplies the environment variable with a true statement.