### PR TITLE
fix: use correct variable in debug logging

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -72,7 +72,7 @@ def point_domain(name, doms):
 
 def check_container_nginx(c, doms):
     if CONTAINER_LOG_LEVEL == "DEBUG" :
-         print ("[debug] Called check_container_nginx for:", s)
+         print ("[debug] Called check_container_nginx for:", c)
     cont_id = c.attrs.get(u'Id')
     for prop in c.attrs.get(u'Config').get(u'Env'):
          if u'VIRTUAL_HOST' in prop or u'DNS_NAME' in prop:


### PR DESCRIPTION
When I set the `CONTAINER_LOG_LEVEL` env var to `DEBUG`, I got an error about an undefined variable. I tracked it down and set it to what I believe you meant the logged value to be. I build my own container and everything worked after I made this change. 

Here's some example output after I made this change:

```
cloudflare-companion   | [debug] Container List Discovery Loop
cloudflare-companion   | [debug] Called check_container_nginx for: <Container: 7f292ac8fe>
cloudflare-companion   | [debug] Container List Discovery Loop
cloudflare-companion   | [debug] Called check_container_nginx for: <Container: 425f8e1059>
cloudflare-companion   | [debug] Container List Discovery Loop
cloudflare-companion   | [debug] Called check_container_nginx for: <Container: 1e3ea5e9d1>
cloudflare-companion   | [debug] Container List Discovery Loop
cloudflare-companion   | [debug] Called check_container_nginx for: <Container: 2444826b42>
```