### PR TITLE
Pin version and convert TTL to int

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x && \
                 && \
     \
     pip install \
-            cloudflare \
+            cloudflare==2.19.* \
             get-docker-secret \
             docker[tls] \
             && \

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -9,7 +9,7 @@ import json
 import os
 import re
 
-DEFAULT_TTL = os.environ.get('DEFAULT_TTL', "1")
+DEFAULT_TTL = os.environ.get('DEFAULT_TTL', 1)
 SWARM_MODE = os.environ.get('SWARM_MODE', "FALSE")
 REFRESH_ENTRIES = os.environ.get('REFRESH_ENTRIES', "FALSE" )
 CONTAINER_LOG_LEVEL = os.environ.get('CONTAINER_LOG_LEVEL', "INFO")
@@ -47,7 +47,7 @@ def point_domain(name, doms):
                 u'type': u'CNAME',
                 u'name': name,
                 u'content': target_domain,
-                u'ttl': dom['ttl'],
+                u'ttl': int(dom['ttl']),
                 u'proxied': dom['proxied']
             }
             if REFRESH_ENTRIES is True :


### PR DESCRIPTION
I've converted the TTL type to fix the error thrown by Cloudflare API changes:
https://github.com/tiredofit/docker-nginx-proxy-cloudflare-companion/issues/7
Also I've changed the Dockerfile so that the version of the Cloudflare package gets pinned because of the pending library rewrite.  